### PR TITLE
Oldschool commands

### DIFF
--- a/snakeware/config/pip_modules.txt
+++ b/snakeware/config/pip_modules.txt
@@ -1,3 +1,4 @@
 pygame_gui
 pyttsx3
 suplemon
+wcwidth

--- a/snakeware/config/pip_modules.txt
+++ b/snakeware/config/pip_modules.txt
@@ -2,5 +2,3 @@ pygame_gui
 pyttsx3
 suplemon
 wcwidth
-pudb
-urwid

--- a/snakeware/config/pip_modules.txt
+++ b/snakeware/config/pip_modules.txt
@@ -2,3 +2,5 @@ pygame_gui
 pyttsx3
 suplemon
 wcwidth
+pudb
+urwid

--- a/snakeware/config/pip_modules.txt
+++ b/snakeware/config/pip_modules.txt
@@ -1,2 +1,3 @@
 pygame_gui
 pyttsx3
+suplemon

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -11,34 +11,6 @@ if not os.path.isfile(THE_CODE_FILE):
         fp.write("")
 THIS_PYTHON = "/usr/bin/python3"
 LESS_PRG = which("less")
-DEBUG_PRG = which("pudb3")
-# TODO: The puDB intro screen with config settings is not to beginner friendly 
-# and should be replaced by writing a configuration file to the appropriate 
-# location. But I can first properly test that when I can build a snakeware 
-# image
-OUR_PUDB_CONFIG = r"""
-[pudb]
-breakpoints_weight = 1
-current_stack_frame = top
-custom_shell =
-custom_stringifier =
-custom_theme =
-default_variables_access_level = all
-display = auto
-hide_cmdline_win = False
-line_numbers = True
-prompt_on_quit = True
-seen_welcome = e036
-shell = internal
-sidebar_width = 0.5
-stack_weight = 1
-stringifier = type
-theme = classic
-variables_weight = 1
-wrap_variables = True
-"""
-PUDB_CONFIG_FILE = f"{os.environ['HOME']}/.config/pudb/pudb.cfg"
-
 
 OUR_SUPLEMON_CONFIG = r"""{
     // Global settings
@@ -116,7 +88,7 @@ if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
 
-LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "debug", "snakewm")
+LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "snakewm")
 
 
 readline.clear_history()
@@ -192,14 +164,6 @@ class SaveCommand(Command):
         return ""
 
 
-class DebugCommand(Command):
-    """Use puDB as debugger of the only program in THE_CODE_FILE."""
-
-    def run(self):
-        _ = subprocess.run([DEBUG_PRG, THE_CODE_FILE])
-        return ""
-
-
 
 snakewm = SnakeWMCommand()
 
@@ -208,4 +172,3 @@ run = RunCommand()
 show = ListCommand()
 save = SaveCommand()
 new = NewCommand()
-debug = DebugCommand()

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -87,6 +87,8 @@ SUPLEMON_CONFIG_FILE = "/tmp/suplemon-config.json"
 if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
+LIST_OF_COMMANDS = ("edit", "run", "list", "save", "new", "snakewm")
+
 
 readline.clear_history()
 
@@ -156,14 +158,7 @@ class SaveCommand(Command):
         with open(THE_CODE_FILE, "w") as fp:
             for idx in range(1, previous_cmd_len):
                 line = readline.get_history_item(idx)
-                if line and not line in (
-                    "edit",
-                    "run",
-                    "list",
-                    "save",
-                    "new",
-                    "snakewm",
-                ):
+                if line and not line in LIST_OF_COMMANDS:
                     fp.write(readline.get_history_item(idx) + "\n")
         return ""
 

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -1,9 +1,14 @@
+import os
 import subprocess
 from shutil import which
 from suplemon.main import App
 
 
 THE_CODE_FILE = "/tmp/code.py"
+# Create an empty file to make sure that `list` and `run` do not crash. 
+if not os.path.isfile(THE_CODE_FILE):
+    with open(THE_CODE_FILE, "w") as fp:
+        fp.write("")
 THIS_PYTHON = "/usr/bin/python3"
 LESS_PRG = which("less")
 

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -3,7 +3,6 @@ import subprocess
 from shutil import which
 from suplemon.main import App
 
-
 THE_CODE_FILE = "/tmp/code.py"
 # Create an empty file to make sure that `list` and `run` do not crash. 
 if not os.path.isfile(THE_CODE_FILE):
@@ -12,6 +11,81 @@ if not os.path.isfile(THE_CODE_FILE):
 THIS_PYTHON = "/usr/bin/python3"
 LESS_PRG = which("less")
 
+OUR_SUPLEMON_CONFIG = r"""{
+    // Global settings
+    "app": {
+        "debug": true,
+        "debug_level": 20,
+        "escdelay": 50,
+        "use_unicode_symbols": false,
+        "imitate_256color": false
+    },
+    // Editor settings
+    "editor": {
+        "auto_indent_newline": true,
+        "end_of_line": "\n",
+        "backspace_unindent": true,
+        "cursor_style": "reverse",
+        "default_encoding": "utf-8",
+        "hard_tabs": 0,
+        "tab_width": 4,
+        "max_history": 50,
+        "punctuation": " (){}[]<>$@!%'\"=+-/*.:,;_\n\r",
+        "line_end_char": "",
+        "white_space_map": {
+            "\u0000": "\u2400",
+            " ": "\u00B7",
+            "\t": "\u21B9",
+            "\u00A0": "\u237D",
+            "\u00AD": "\u2423",
+            "\u00A0": "\u2420",
+            "\u180E": "\u2420",
+            "\u2000": "\u2420",
+            "\u2001": "\u2420",
+            "\u2002": "\u2420",
+            "\u2003": "\u2420",
+            "\u2004": "\u2420",
+            "\u2005": "\u2420",
+            "\u2006": "\u2420",
+            "\u2007": "\u2420",
+            "\u2008": "\u2420",
+            "\u2009": "\u2420",
+            "\u200A": "\u2420",
+            "\u200B": "\u2420",
+            "\u202F": "\u2420",
+            "\u205F": "\u2420",
+            "\u3000": "\u2420",
+            "\uFEFF": "\u2420"
+        },
+        "show_white_space": false,
+        "show_tab_indicators": true,
+        "tab_indicator_character": "\u203A",
+        "highlight_current_line": true,
+        "show_line_nums": true,
+        "line_nums_pad_space": true,
+        "show_line_colors": true,
+        "show_highlighting": true,
+        "theme": "monokai",
+        "use_mouse": false,
+        "use_global_buffer": true,
+        "regex_find": false
+    },
+    // UI Display Settings
+    "display": {
+        "show_top_bar": true,
+        "show_app_name": true,
+        "show_file_list": true,
+        "show_file_modified_indicator": true,
+        "show_legend": true,
+        "show_bottom_bar": true,
+        "invert_status_bars": false
+    }
+}
+"""
+SUPLEMON_CONFIG_FILE = "/tmp/suplemon-config.json"
+if not os.path.isfile(SUPLEMON_CONFIG_FILE):
+    with open(SUPLEMON_CONFIG_FILE, "w") as fp:
+        fp.write(OUR_SUPLEMON_CONFIG)
 
 class Command:
     """Defines a command which is run when repr(self) is evaluated."""
@@ -36,7 +110,7 @@ class EditCommand(Command):
     """Start suplemon with this single file to edit."""
 
     def __repr__(self):
-        app = App(filenames=[THE_CODE_FILE])
+        app = App(filenames=[THE_CODE_FILE], config_file=SUPLEMON_CONFIG_FILE)
         if app.init():
             app.run()
             return "I stored your code."

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -1,9 +1,19 @@
+import subprocess
+from shutil import which
+from suplemon.main import App
+
+
+THE_CODE_FILE = "/tmp/code.py"
+THIS_PYTHON = "/usr/bin/python3"
+LESS_PRG = which("less")
+
+
 class Command:
     """Defines a command which is run when repr(self) is evaluated."""
 
     def run(self):
         raise NotImplementedError
-        
+
     def __repr__(self):
         """Execute the command."""
         return self.run()
@@ -13,7 +23,39 @@ class SnakeWMCommand(Command):
     def run(self):
         """Start SnakeWM."""
         from snakewm.wm import SnakeWM
+
         return SnakeWM().run()
 
 
+class EditCommand(Command):
+    """Start suplemon with this single file to edit."""
+
+    def __repr__(self):
+        app = App(filenames=[THE_CODE_FILE])
+        if app.init():
+            app.run()
+            return "I stored your code."
+
+
+class RunCommand:
+    """Run the only program that we have in THE_CODE_FILE."""
+
+    def __repr__(self):
+        _ = subprocess.run([THIS_PYTHON, THE_CODE_FILE])
+        return ""
+
+
+class ListCommand:
+    """Use less to show the contents of the only program that we have in 
+    THE_CODE_FILE."""
+
+    def __repr__(self):
+        _ = subprocess.run([LESS_PRG, THE_CODE_FILE])
+        return ""
+
+
 snakewm = SnakeWMCommand()
+
+edit = EditCommand()
+run = RunCommand()
+list = ListCommand()

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -109,26 +109,26 @@ class SnakeWMCommand(Command):
 class EditCommand(Command):
     """Start suplemon with this single file to edit."""
 
-    def __repr__(self):
+    def run(self):
         app = App(filenames=[THE_CODE_FILE], config_file=SUPLEMON_CONFIG_FILE)
         if app.init():
             app.run()
             return "I stored your code."
 
 
-class RunCommand:
+class RunCommand(Command):
     """Run the only program that we have in THE_CODE_FILE."""
 
-    def __repr__(self):
+    def run(self):
         _ = subprocess.run([THIS_PYTHON, THE_CODE_FILE])
         return ""
 
 
-class ListCommand:
+class ListCommand(Command):
     """Use less to show the contents of the only program that we have in 
     THE_CODE_FILE."""
 
-    def __repr__(self):
+    def run(self):
         _ = subprocess.run([LESS_PRG, THE_CODE_FILE])
         return ""
 

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -88,7 +88,7 @@ if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
 
-LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "snakewm")
+LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "snakewm", "snakegames")
 
 
 readline.clear_history()
@@ -167,7 +167,7 @@ class SaveCommand(Command):
 class SnakeGamesCommand(Command):
     def run(self):
         """Start SnakeWM."""
-        from snake_games.gamemenu  import SnakeGameMenu
+        from snake_games.gamemenu import SnakeGameMenu
 
         return SnakeGameMenu().menu()
 

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -11,6 +11,34 @@ if not os.path.isfile(THE_CODE_FILE):
         fp.write("")
 THIS_PYTHON = "/usr/bin/python3"
 LESS_PRG = which("less")
+DEBUG_PRG = which("pudb3")
+# TODO: The puDB intro screen with config settings is not to beginner friendly 
+# and should be replaced by writing a configuration file to the appropriate 
+# location. But I can first properly test that when I can build a snakeware 
+# image
+OUR_PUDB_CONFIG = r"""
+[pudb]
+breakpoints_weight = 1
+current_stack_frame = top
+custom_shell =
+custom_stringifier =
+custom_theme =
+default_variables_access_level = all
+display = auto
+hide_cmdline_win = False
+line_numbers = True
+prompt_on_quit = True
+seen_welcome = e036
+shell = internal
+sidebar_width = 0.5
+stack_weight = 1
+stringifier = type
+theme = classic
+variables_weight = 1
+wrap_variables = True
+"""
+PUDB_CONFIG_FILE = f"{os.environ['HOME']}/.config/pudb/pudb.cfg"
+
 
 OUR_SUPLEMON_CONFIG = r"""{
     // Global settings
@@ -87,7 +115,8 @@ SUPLEMON_CONFIG_FILE = "/tmp/suplemon-config.json"
 if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
-LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "snakewm")
+
+LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "debug", "snakewm")
 
 
 readline.clear_history()
@@ -163,6 +192,15 @@ class SaveCommand(Command):
         return ""
 
 
+class DebugCommand(Command):
+    """Use puDB as debugger of the only program in THE_CODE_FILE."""
+
+    def run(self):
+        _ = subprocess.run([DEBUG_PRG, THE_CODE_FILE])
+        return ""
+
+
+
 snakewm = SnakeWMCommand()
 
 edit = EditCommand()
@@ -170,3 +208,4 @@ run = RunCommand()
 show = ListCommand()
 save = SaveCommand()
 new = NewCommand()
+debug = DebugCommand()

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -87,7 +87,7 @@ SUPLEMON_CONFIG_FILE = "/tmp/suplemon-config.json"
 if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
-LIST_OF_COMMANDS = ("edit", "run", "list", "save", "new", "snakewm")
+LIST_OF_COMMANDS = ("edit", "run", "show", "save", "new", "snakewm")
 
 
 readline.clear_history()
@@ -167,6 +167,6 @@ snakewm = SnakeWMCommand()
 
 edit = EditCommand()
 run = RunCommand()
-list = ListCommand()
+show = ListCommand()
 save = SaveCommand()
 new = NewCommand()

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -164,6 +164,13 @@ class SaveCommand(Command):
         return ""
 
 
+class SnakeGamesCommand(Command):
+    def run(self):
+        """Start SnakeWM."""
+        from snake_games.gamemenu  import SnakeGameMenu
+
+        return SnakeGameMenu().menu()
+
 
 snakewm = SnakeWMCommand()
 
@@ -172,3 +179,4 @@ run = RunCommand()
 show = ListCommand()
 save = SaveCommand()
 new = NewCommand()
+snakegames = SnakeGamesCommand()

--- a/snakeware/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/overlay/usr/share/snakeware/startup.py
@@ -1,10 +1,11 @@
 import os
+import readline
 import subprocess
 from shutil import which
 from suplemon.main import App
 
 THE_CODE_FILE = "/tmp/code.py"
-# Create an empty file to make sure that `list` and `run` do not crash. 
+# Create an empty file to make sure that `list` and `run` do not crash.
 if not os.path.isfile(THE_CODE_FILE):
     with open(THE_CODE_FILE, "w") as fp:
         fp.write("")
@@ -87,6 +88,9 @@ if not os.path.isfile(SUPLEMON_CONFIG_FILE):
     with open(SUPLEMON_CONFIG_FILE, "w") as fp:
         fp.write(OUR_SUPLEMON_CONFIG)
 
+readline.clear_history()
+
+
 class Command:
     """Defines a command which is run when repr(self) is evaluated."""
 
@@ -133,8 +137,41 @@ class ListCommand(Command):
         return ""
 
 
+class NewCommand(Command):
+    """Empty the current program"""
+
+    def run(self):
+        readline.clear_history()
+        with open(THE_CODE_FILE, "w") as fp:
+            fp.write("")
+        return ""
+
+
+class SaveCommand(Command):
+    """Save the previously entered statements as current program."""
+
+    def run(self):
+        previous_cmd_len = readline.get_current_history_length()
+
+        with open(THE_CODE_FILE, "w") as fp:
+            for idx in range(1, previous_cmd_len):
+                line = readline.get_history_item(idx)
+                if line and not line in (
+                    "edit",
+                    "run",
+                    "list",
+                    "save",
+                    "new",
+                    "snakewm",
+                ):
+                    fp.write(readline.get_history_item(idx) + "\n")
+        return ""
+
+
 snakewm = SnakeWMCommand()
 
 edit = EditCommand()
 run = RunCommand()
 list = ListCommand()
+save = SaveCommand()
+new = NewCommand()


### PR DESCRIPTION
Hej Josh,

I saw your project on HN earlier today and got really exited about it. I was searching for something like this for some time already since I think it would be a perfect environment for teaching programming to beginners.

Based on [GarbageHamburger](https://github.com/GarbageHamburger)'s [pull request](https://github.com/joshiemoore/snakeware/pull/45), I built three more commands that I think could contribute to the home computer feeling. These are:

  * `edit` ... opens [suplemon](https://github.com/richrd/suplemon) to write a single Python module
  * `list` ... uses `less` to print the contents of that file 
  * `run` ... runs that single program

I understand your concern about recreating a shell but I had the idea that it would be nice to work, next to the REPL, in a mode similar to a C64. That is, one can have a single _active_ program (which for the moment is stored in `/tmp/code.py`). That program can be edited, listed, and executed...

I have not yet tried to build a new image including this code. I will do that later as soon as I am again on a Linux box. But I guess (from running it directly on my host machine) it should work in its current state.