### PR TITLE
Add CPU monitor

### DIFF
--- a/snakewm/apps/tools/cpumon/README.md
+++ b/snakewm/apps/tools/cpumon/README.md
@@ -1,5 +1,7 @@
 # cpumon
-Displays a bar graph of CPU usage
+Displays a bar graph of CPU usage.
+
+Data is either read via ``psutil`` if available or directly from ``/proc/stat`` (only works on Linux).
 
 # Author
 

--- a/snakewm/apps/tools/cpumon/README.md
+++ b/snakewm/apps/tools/cpumon/README.md
@@ -1,0 +1,10 @@
+# cpumon
+Displays a bar graph of CPU usage
+
+# Author
+
+Martin C. Doege
+
++ github: https://github.com/mdoege
+
++ date: 5 Jun 2020

--- a/snakewm/apps/tools/cpumon/__init__.py
+++ b/snakewm/apps/tools/cpumon/__init__.py
@@ -1,0 +1,14 @@
+from .cpumon import SnakeMon
+
+
+def load(manager, params):
+    """
+    Create and launch a new instance of SnakeMon.
+    """
+    # default position
+    pos = (100, 100)
+
+    if params is not None and len(params) > 0:
+        pos = params[0]
+
+    SnakeMon(pos, manager)

--- a/snakewm/apps/tools/cpumon/cpumon.py
+++ b/snakewm/apps/tools/cpumon/cpumon.py
@@ -1,0 +1,71 @@
+# CPU usage monitor
+
+import time
+import pygame
+import pygame_gui
+from pygame_gui.elements.ui_image import UIImage
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+    from .cpuproc import cpuproc
+
+BLUE = 68, 174, 220
+GRAY = 76, 80, 82
+
+
+class SnakeMon(pygame_gui.elements.UIWindow):
+    DIMS = (200, 100)
+
+    def __init__(self, pos, manager):
+        super().__init__(
+            pygame.Rect(pos, (self.DIMS[0] + 32, self.DIMS[1] + 60)),
+            manager=manager,
+            window_display_title="cpumon",
+            object_id="#cpumonterm",
+            resizable=False,
+        )
+
+        self.dsurf = UIImage(
+            pygame.Rect((0, 0), self.DIMS),
+            pygame.Surface(self.DIMS).convert(),
+            manager=manager,
+            container=self,
+            parent_element=self,
+        )
+        self.cpu = pygame.Surface(self.DIMS)
+        self.cpu.fill(GRAY)
+        self.last_time = 0
+
+    def process_event(self, event):
+        super().process_event(event)
+
+    def update(self, delta):
+        super().update(delta)
+        # limit frame rate to 4 FPS
+        if time.time() - self.last_time > 0.25:
+            self.draw_cpu()
+            self.last_time = time.time()
+        self.dsurf.image.blit(self.cpu, (0, 0))
+
+    def draw_cpu(self):
+        if psutil:
+            cpu_perc = int(psutil.cpu_percent(interval=None))
+        else:
+            cpu_perc = cpuproc()
+        self.cpu.scroll(dx=-1)
+        pygame.draw.line(
+            self.cpu,
+            GRAY,
+            ((self.DIMS[0] - 1), self.DIMS[1] - 1),
+            ((self.DIMS[0] - 1), 0),
+            1,
+        )
+        pygame.draw.line(
+            self.cpu,
+            BLUE,
+            ((self.DIMS[0] - 1), self.DIMS[1] - 1),
+            ((self.DIMS[0] - 1), self.DIMS[1] - cpu_perc),
+            1,
+        )

--- a/snakewm/apps/tools/cpumon/cpuproc.py
+++ b/snakewm/apps/tools/cpumon/cpuproc.py
@@ -1,3 +1,6 @@
+# Read CPU usage in percent from /proc/stat
+# (only works on Linux)
+
 import time
 
 o = 0
@@ -20,6 +23,7 @@ def cpuproc():
     return int(q)
 
 
+# Test the module
 if __name__ == "__main__":
     while True:
         print(cpuproc())

--- a/snakewm/apps/tools/cpumon/cpuproc.py
+++ b/snakewm/apps/tools/cpumon/cpuproc.py
@@ -1,0 +1,26 @@
+import time
+
+o = 0
+t = time.time()
+numcpu = 1
+for l in open("/proc/stat"):
+    x = l.split()
+    if l[:3] == "cpu" and len(x[0]) > 3:
+        numcpu = 1 + int(x[0][3:])
+
+
+def cpuproc():
+    global o, t
+    f = open("/proc/stat").readline().split()
+    q = 0.01 * (int(f[4]) - o) / (time.time() - t)
+    q = 100 * (1 - q / numcpu)
+    q = max(0, min(100, q))
+    t = time.time()
+    o = int(f[4])
+    return int(q)
+
+
+if __name__ == "__main__":
+    while True:
+        print(cpuproc())
+        time.sleep(1)


### PR DESCRIPTION
A simple scrolling CPU usage monitor. It uses ``psutil`` (https://pypi.org/project/psutil/) if available and if that is not installed as on Snakeware right now, it falls back to reading ``/proc/stat`` directly which only works on Linux.

If you run this in QEMU, CPU usage is always  close to 100%, so it does not tell you much except performance in QEMU is bad. But on real hardware it looks much better and more informative.
