### PR TITLE
Added inputted commands to visible snaketerm history

### DIFF
--- a/snakewm/apps/tools/snaketerm/term.py
+++ b/snakewm/apps/tools/snaketerm/term.py
@@ -137,7 +137,8 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
             sys.stdout = tout = StringIO()
 
             try:
-                code = compile(self.input.get_text(), "snaketerm_code", "exec")
+                input_command = self.input.get_text()
+                code = compile(input_command, "snaketerm_code", "exec")
                 exec(code, globals())
             except Exception:
                 e_type, e_val, e_traceback = sys.exc_info()
@@ -147,6 +148,7 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
 
             sys.stdout = _stdout
             result = tout.getvalue()
+            self.append_text(">>> " + input_command + "\n")
             self.append_text(result)
             self.add_to_history(self.input.get_text())
             self.histindex = -1

--- a/snakewm/apps/tools/snaketerm/term.py
+++ b/snakewm/apps/tools/snaketerm/term.py
@@ -96,7 +96,7 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
 
     def append_text(self, text, is_command=False):
         if is_command:
-            self.textbox.html_text += ">>> " + text.replace("\n", "<br>") + "<br>" 
+            self.textbox.html_text += ">>> " + text.replace("\n", "<br>") + "<br>"
         else:
             self.textbox.html_text += text.replace("\n", "<br>")
         self.textbox.rebuild()

--- a/snakewm/apps/tools/snaketerm/term.py
+++ b/snakewm/apps/tools/snaketerm/term.py
@@ -96,9 +96,9 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
 
     def append_text(self, text, is_command=False):
         if is_command:
-            self.textbox.html_text = self.textbox.html_text + ">>> " + text.replace("\n", "<br>") + "<br>" 
+            self.textbox.html_text += ">>> " + text.replace("\n", "<br>") + "<br>" 
         else:
-            self.textbox.html_text = self.textbox.html_text + text.replace("\n", "<br>")
+            self.textbox.html_text += text.replace("\n", "<br>")
         self.textbox.rebuild()
         if self.textbox.scroll_bar is not None:
             self.textbox.scroll_bar.scroll_position = (

--- a/snakewm/apps/tools/snaketerm/term.py
+++ b/snakewm/apps/tools/snaketerm/term.py
@@ -94,8 +94,11 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
         self.input.set_text(command[:ep] + command[to_pos:])
         self.input.edit_position = ep
 
-    def append_text(self, text):
-        self.textbox.html_text = self.textbox.html_text + text.replace("\n", "<br>")
+    def append_text(self, text, is_command=False):
+        if is_command:
+            self.textbox.html_text = self.textbox.html_text + ">>> " + text.replace("\n", "<br>") + "<br>" 
+        else:
+            self.textbox.html_text = self.textbox.html_text + text.replace("\n", "<br>")
         self.textbox.rebuild()
         if self.textbox.scroll_bar is not None:
             self.textbox.scroll_bar.scroll_position = (
@@ -136,8 +139,8 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
             _stdout = sys.stdout
             sys.stdout = tout = StringIO()
 
+            input_command = self.input.get_text()
             try:
-                input_command = self.input.get_text()
                 code = compile(input_command, "snaketerm_code", "exec")
                 exec(code, globals())
             except Exception:
@@ -148,9 +151,9 @@ class SnakeTerm(pygame_gui.elements.UIWindow):
 
             sys.stdout = _stdout
             result = tout.getvalue()
-            self.append_text(">>> " + input_command + "\n")
+            self.append_text(input_command, is_command=True)
             self.append_text(result)
-            self.add_to_history(self.input.get_text())
+            self.add_to_history(input_command)
             self.histindex = -1
             self.flush_command_cache()
             self.input.set_text(str())


### PR DESCRIPTION
Now typed commands appear in the output box in an IDLE-eqsue way
![image](https://user-images.githubusercontent.com/24368336/84180245-c0e31280-aab9-11ea-8d28-05ff694d70d9.png)
