### PR TITLE
Fix reboot/shutdown

### DIFF
--- a/snakewm/apps/system/reboot/__init__.py
+++ b/snakewm/apps/system/reboot/__init__.py
@@ -1,6 +1,7 @@
 import os
+import pygame
 
 
 def load(manager, params):
+    pygame.quit()
     os.system("/sbin/reboot -f")
-    exit()

--- a/snakewm/apps/system/reboot/__init__.py
+++ b/snakewm/apps/system/reboot/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+
+def load(manager, params):
+    os.system("/sbin/reboot -f")
+    exit()

--- a/snakewm/apps/system/shutdown/__init__.py
+++ b/snakewm/apps/system/shutdown/__init__.py
@@ -1,6 +1,7 @@
 import os
+import pygame
 
 
 def load(manager, params):
+    pygame.quit()
     os.system("/sbin/poweroff -f")
-    exit()

--- a/snakewm/apps/system/shutdown/__init__.py
+++ b/snakewm/apps/system/shutdown/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+
+def load(manager, params):
+    os.system("/sbin/poweroff -f")
+    exit()


### PR DESCRIPTION
Fixes the issue with the shutdown/reboot apps.
Now, there is no context menu, but when you click the app, it just shuts down, similar to "exit snakewm."
It still doesn't work when other windows are open, but if you close all windows it works.
If you have a fix for this, please tell me and I'll add it as a commit to this pr.
Also, I've only tested it on my arch box, as the build fails on my computer.