### PR TITLE
speaknspell: Add ability to use input from history

### DIFF
--- a/snakewm/apps/fun/speaknspell/speak.py
+++ b/snakewm/apps/fun/speaknspell/speak.py
@@ -54,6 +54,12 @@ class SpeakSpell(pygame_gui.elements.UIWindow):
         self.speak("Hello, thank you for using snakeware!")
         self.input.focus()
 
+        # history attributes
+        self.histsize = 100
+        self.histindex = -1
+        self.history = ["Hello, thank you for using snakeware"]
+        self.cached_command = ""
+
     def speak(self, text):
         if self.speakthrd is not None and self.speakthrd.is_alive():
             return
@@ -71,8 +77,44 @@ class SpeakSpell(pygame_gui.elements.UIWindow):
         self.box.rebuild()
         self.input.set_text("")
 
+    def cache_command(self):
+        self.cached_command = self.input.get_text()
+
+    def flush_command_cache(self):
+        self.cached_command = ""
+
+    def set_histindex(self, increment):
+        try:
+            # self.history[self.histindex + increment]
+            self.histindex += increment
+        except IndexError:
+            pass
+        return self.histindex
+
+    def set_from_history(self):
+        if self.histindex > -1:
+            self.input.set_text(self.history[self.histindex])
+        else:
+            self.input.set_text(self.cached_command)
+        self.input.edit_position = len(self.input.get_text())
+
+    def add_to_history(self, text):
+        self.history = [text] + self.history
+        if len(self.history) > self.histsize:
+            del self.history[-1]
+
     def process_event(self, event):
         super().process_event(event)
         if event.type == pygame.USEREVENT and event.ui_element == self.input:
             if event.user_type == pygame_gui.UI_TEXT_ENTRY_FINISHED:
-                self.speak(self.input.get_text())
+                text = self.input.get_text()
+                self.add_to_history(text)
+                self.histindex = -1
+                self.flush_command_cache()
+                self.speak(text)
+        elif event.type == pygame.KEYUP and event.key in (pygame.K_UP, pygame.K_DOWN):
+            increment = 1 if event.key == pygame.K_UP else -1
+            if self.histindex == -1:
+                self.cache_command()
+            self.set_histindex(increment)
+            self.set_from_history()

--- a/snakewm/apps/fun/speaknspell/speak.py
+++ b/snakewm/apps/fun/speaknspell/speak.py
@@ -67,8 +67,7 @@ class SpeakSpell(pygame_gui.elements.UIWindow):
         if text == "":
             return
 
-        text = text.replace("\n", "<br>")
-
+        text = re.sub(r"(\\r)?\\n", "<br>", text)
         spoken = re.sub(r"<(.*?)>", "", text)
         self.engine.say(spoken)
         self.speakthrd = threading.Thread(target=self.engine.runAndWait, args=())

--- a/snakewm/apps/fun/speaknspell/speak.py
+++ b/snakewm/apps/fun/speaknspell/speak.py
@@ -57,7 +57,7 @@ class SpeakSpell(pygame_gui.elements.UIWindow):
         # history attributes
         self.histsize = 100
         self.histindex = -1
-        self.history = ["Hello, thank you for using snakeware"]
+        self.history = ["Hello, thank you for using snakeware!"]
         self.cached_command = ""
 
     def speak(self, text):


### PR DESCRIPTION
Allows users to press the Up arrow and re-use old inputs.
This is useful for longer inputs and inputs with many HTML tags.