### PR TITLE
Add shutdown and reboot commands

### DIFF
--- a/snakeware/external/overlay/usr/share/snakeware/startup.py
+++ b/snakeware/external/overlay/usr/share/snakeware/startup.py
@@ -17,4 +17,18 @@ class SnakeWMCommand(Command):
         return SnakeWM().run()
 
 
+class ShutdownCommand(Command):
+    def run(self):
+        import os
+        os.system("/sbin/poweroff -f")
+
+
+class RebootCommand(Command):
+    def run(self):
+        import os
+        os.system("/sbin/reboot -f")
+
+
 snakewm = SnakeWMCommand()
+shutdown = ShutdownCommand()
+reboot = RebootCommand()


### PR DESCRIPTION
This provides an easy way to shutdown and reboot the system from the
python interpreter without having to start snakewm or directly working with
os or subprocess.
Can confirm that they both work in the snakeware image.