### PR TITLE
Add instruction for errors in arch-based distros

### DIFF
--- a/snakeware/README.md
+++ b/snakeware/README.md
@@ -21,8 +21,39 @@ If the build is successful, a `snakeware.iso` file will be generated and placed 
 
 You can run this image in QEMU, or dd it to a flash drive to try running it on real hardware.
 
+
 ## Other info
-TODO
+
+### Errors on archlinux/manjaro(fakeroot build problems)
+
+To build it success we can chroot into debian/ubuntu(debian lightweight).
+
+Install debootstrap -> `sudo pacman -S debootstrap`
+After install debian-chroot -> `debootstrap stable ./buildroot-debian-stable`        
+After download you can see debian-stable rootfs in dir `buildroot-debian-stable`. cd to dir.  
+  Mounting pseudo-filesystems
+`sudo mount proc -t proc ./proc && sudo mount sys -t sysfs ./sys && sudo mount --bind /dev ./dev && sudo mount --bind /dev/pts ./dev/pts`
+
+Chroot! -> `chroot ./ /usr/bin/env -i HOME=/root PS1="(buildroot): "TERM="$TERM" /bin/bash --login`
+
+Setup it. 
+1. Set root password: `passwd`
+2. Set timezone: `ln -sf /usr/share/zoneinfo/UTC /etc/localtime`
+3. For df work -> `cat >/etc/mtab <<EOF  
+rootfs / rootfs rw 0 0  
+EOF`
+4. Check for ethernet system: apt update
+5. If you get DNS error, copy resolv.conf from **your system(not chroot)**: `cp /etc/resolv.conf ./etc/resolv.conf`
+6. install dependieces: `apt install file gcc g++ make mercurial wget rsync unzip bc git`
+7. Add user: `adduser builder`
+8. Set password for user: passwd builder
+9. su - builder
+10. Go to instruction and do all steps.
+11. Enjoy!
+## Other info
+
+
+
 
 ## Ports
 snakeware will always be primarily focused on x86-64, but buildroot makes it possible to build for


### PR DESCRIPTION
Add instruction for arch-based. Tested on archlinux. 
Now in buildroot problems with building(developers don't fix it. Issue created in 2020.)
